### PR TITLE
[Feat] Checking if the virtual text is disabled by the user

### DIFF
--- a/lua/circles.lua
+++ b/lua/circles.lua
@@ -64,11 +64,15 @@ M.setup = function(user_config)
   else
     -- An else condition is required here because the default diagnostic icon
     -- may not be retrievable due to `vim` being a global variable.
-    vim.diagnostic.config({
-      virtual_text = {
-        prefix = '■',
-      },
-    })
+    local is_enable = vim.diagnostic.config().virtual_text ~= false
+
+    if is_enable then
+      vim.diagnostic.config({
+        virtual_text = {
+          prefix = '■',
+        },
+      })
+    end
   end
 end
 


### PR DESCRIPTION
First, thanks for a great plugin.

Motivation:
At the moment, the plugin sets the prefix by default, even if virtual text is disabled in the user settings.
For example, I always [disable](https://github.com/Wansmer/nvim-config/blob/203d4465f0e9e37ea82b7796d13282057071332e/lua/config/lsp/diagnostics.lua#L3) virtual text for diagnostics, but the plugin overwrites my value and sets the square even if I specify `lsp=false` in the plugin settings.

This PR adds a check that the `virtual_text` has not been disabled by the user.